### PR TITLE
Fix recursive char stripping when parsing recursive values

### DIFF
--- a/key.go
+++ b/key.go
@@ -133,8 +133,7 @@ func (k *Key) transformValue(val string) string {
 		}
 
 		// Take off leading '%(' and trailing ')s'.
-		noption := strings.TrimLeft(vr, "%(")
-		noption = strings.TrimRight(noption, ")s")
+		noption := vr[2 : len(vr)-2]
 
 		// Search in the same section.
 		nk, err := k.s.GetKey(noption)

--- a/key_test.go
+++ b/key_test.go
@@ -514,10 +514,13 @@ func TestRecursiveValues(t *testing.T) {
 	Convey("Recursive values should not reflect on same key", t, func() {
 		f, err := ini.Load([]byte(`
 NAME = ini
+expires = yes
 [package]
-NAME = %(NAME)s`))
+NAME = %(NAME)s
+expires = %(expires)s`))
 		So(err, ShouldBeNil)
 		So(f, ShouldNotBeNil)
 		So(f.Section("package").Key("NAME").String(), ShouldEqual, "ini")
+		So(f.Section("package").Key("expires").String(), ShouldEqual, "yes")
 	})
 }


### PR DESCRIPTION
### What problem should be fixed?

### Have you added test cases to catch the problem?
